### PR TITLE
Fix incorrect usage of MCQJudge.judge() in README.md and docs/quickst…

### DIFF
--- a/README.md
+++ b/README.md
@@ -302,7 +302,7 @@ logs = []
 for sample in dataset:
     prompt = template(sample)
     response = llm(prompt)
-    judge_output, score = judge(response)
+    judge_output, score = judge(response, sample.answer)
     
     logs.append({
 	    "sample": sample.model_dump(),

--- a/docs/quickstart/mcq.md
+++ b/docs/quickstart/mcq.md
@@ -50,7 +50,7 @@ logs = []
 for sample in dataset:
     prompt = template(sample)
     response = llm(prompt)
-    judge_output, score = judge(response)
+    judge_output, score = judge(response, sample.answer)
     
     logs.append({
 	    "sample": sample.model_dump(),


### PR DESCRIPTION
### Description
This PR fixes the incorrect usage of the `MCQJudge.judge()` method in two code examples:
1. `README.md`
2. `docs/quickstart/mcq.md`

Previously, the method was called with only one argument, which caused the score to always return `false` due to the missing second argument (the correct answer). This PR updates both examples to pass the required second argument, ensuring correct functionality.

### Changes
- Updated `README.md` example to include the correct call to `MCQJudge.judge(answer, correct_answer)`
- Updated `docs/quickstart/mcq.md` with the same fix.

### Testing
Verified the correctness of the method call and confirmed that the score is calculated properly when both arguments are passed.

### Related Issue
Fixes #114 [](https://github.com/walledai/walledeval/issues/114)